### PR TITLE
Fix lager backend init/1 signature

### DIFF
--- a/src/raven_lager_backend.erl
+++ b/src/raven_lager_backend.erl
@@ -16,6 +16,8 @@
 
 -record(state, {level}).
 
+init(Level) when is_atom(Level) ->
+    init([{level, Level}]);
 init([{level, Level}]) ->
     {ok, #state{level=lager_util:level_to_num(Level)}}.
 


### PR DESCRIPTION
Stumble upon `function_clause` issue when using with lager 3.X. This pull request makes it works again.