### PR TITLE
Remove beehive special case

### DIFF
--- a/src/raven_error_logger.erl
+++ b/src/raven_error_logger.erl
@@ -277,17 +277,6 @@ parse_message(Level, Pid, "Exception: ~p\n"
 			{pid, Pid} | [ {Key, Value} || {Key, Value} <- Extras, is_atom(Key) ]
 		]}
 	]};
-%% Beehive
-parse_message(Level, Pid, "ULog error: ~p" = Format, [Reason] = _Data) ->
-	{Exception, Stacktrace} = parse_reason(Reason),
-	{format(Format, [Exception]), [
-		{level, Level},
-		{exception, Exception},
-		{stacktrace, Stacktrace},
-		{extra, [
-			{pid, Pid}
-		]}
-	]};
 %% Cybertron
 parse_message(Level, Pid, "~p failed for 5 minutes: ~p" = Format,
 			  [cybertron_email, {error, Status, _Headers, _Body}] = Data) ->


### PR DESCRIPTION
It's quite brittle to pattern match on a specific line in another repo, and I'm sure this will sonner or later shot some poor dev in the foot. Fortunately it's an easy fix, done in https://github.com/kivra/beehive/pull/117. After that one, this can be merged to remove it.