### PR TITLE
Support Sentry users for general error macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .*
 /deps/
 /ebin/
+/_build
+rebar.lock


### PR DESCRIPTION

The ?failed and ?exception macros get picked up by parse_message already
and allow attaching arbitray extra data to be sent to Sentry.

This makes it so that attaching `user` as extra data is sent as a proper
raven user, allowing Sentry to do smart things like count the number of
affected users and searching for all issues related to this user.