### PR TITLE
fix: Bug in parse_message

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,6 +6,6 @@
 	{platform_define, "^R14", no_callbacks}
 ]}.
 {deps, [
-	{jsx, ".*", {git, "git@github.com:talentdeficit/jsx.git", {branch, master}}},
-	{stdlib2,   {git, "git@github.com:kivra/stdlib2.git",     {branch, master}}}
+	{jsx, ".*", {git, "git@github.com:kivra/jsx.git",     {tag, "2.9.0"}}},
+	{stdlib2,   {git, "git@github.com:kivra/stdlib2.git", {branch, master}}}
 ]}.

--- a/src/raven_error_logger.erl
+++ b/src/raven_error_logger.erl
@@ -284,10 +284,8 @@ parse_message(Level, Pid, "Exception: ~p\n"
 			  [{{Class, Reason}, [{_, _, _, _} | _] = Stacktrace}, Extras])
 		when Class =:= exit; Class =:= error; Class =:= throw ->
 	{User, ExtrasWithoutUser} = extract_user(Extras),
-	ExtrasLevel = proplists:get_value(level, Extras, false),
-	TheLevel = ExtrasLevel orelse Level,
 	{format(Format, [{Class, Reason}, Extras]), [
-		{level, TheLevel},
+		{level, proplists:get_value(level, Extras, Level)},
 		{exception, {Class, Reason}},
 		{stacktrace, Stacktrace},
 		{extra, [


### PR DESCRIPTION
## About

`raven_error_logger` is removed from the list of `error_logger` event listeners every time we hit [this exception in kivra_core](https://github.com/kivra/kivra_core/blob/7763077ead0679c756b00640df7d136b9535ba4a/src/kivra_core/active_content.erl#L85-L88). What I can see in the `kivra_core` logs is something like this:

```
14:57:27.149 [error] Exception: {{throw,{error,timeout}},[{s2_maybe,unlift,1,[{file,"/build/kivra_core/_build/default/lib/stdlib2/src/s2_maybe.erl"},{line,93}]},{client_kampanha,access_token,3,[{file,"/build/kivra_core/src/kivra_client/client_kampanha.erl"},{line,101}]},{client_kampanha,get_content_campaigns,2,[{file,"/build/kivra_core/src/kivra_client/client_kampanha.erl"},{line,42}]},{active_content,overlay,6,[{file,"/build/kivra_core/src/kivra_core/active_content.erl"},{line,52}]},{rest_user_content_key_v2,get_content,1,[{file,"/build/kivra_core/src/rest/user/rest_user_content_key_v2.erl"},{line,93}]},{timer,tc,1,[{file,"timer.erl"},{line,166}]},{kivra_metrics,time_mfa,2,[{file,"/build/kivra_core/_build/default/lib/kivra_metrics/src/kivra_metrics.erl"},{line,43}]},{s2_maybe,lift,1,[{file,"/build/kivra_core/_build/default/lib/stdlib2/src/s2_maybe.erl"},{line,74}]}]}
14:57:27.149 [error] gen_event raven_error_logger installed in error_logger terminated with reason: {badarg,warning}
```

I think this is because the following line in `raven_error_logger` is not valid Erlang:

```erlang
TheLevel = ExtrasLevel orelse Level
```

Since `ExtrasLevel = warning` in the case of the above exception, the above line boils down to something like this:

```erlang
TheLevel = warning orelse error
```

which will throw an exception `** exception error: bad argument: warning` since the term on the left side of `orelse` is not a boolean.