### PR TITLE
chore: Use 'reason' field when provided (defaults to message)

### DIFF
--- a/src/raven_logger_backend.erl
+++ b/src/raven_logger_backend.erl
@@ -102,7 +102,7 @@ get_args(Message, LogEvent) ->
 	MetaBasic  = maps:with(?ATTRIBUTE_FILTER, Meta),
 	MetaExtra  = maps:without(?ATTRIBUTE_FILTER, Meta),
 	Msg        = maps:get(msg, LogEvent),
-	Reason     = Message,
+	Reason     = get_reason_maybe(LogEvent, Message),
 	Basic      = MetaBasic#{level => Level},
 	Extra      = get_extra(Reason, MetaExtra, Msg),
 
@@ -119,6 +119,11 @@ get_args(Message, LogEvent) ->
 
 sentry_level(notice) -> info;
 sentry_level(Level) -> Level.
+
+get_reason_maybe(#{msg := {report, #{reason := Reason}}} = _LogEvent, _Default) ->
+        Reason;
+get_reason_maybe(_LogEvent, Default) ->
+        Default.
 
 get_extra(Reason, ExtraMeta, {report, Report}) ->
 	Extra = maps:merge(ExtraMeta, Report),


### PR DESCRIPTION
## Description

Currently, `reason` field defaults to the message which is just a copy of the title. This PR changes it to use the reason passed down from the report if available