### PR TITLE
Improve HTTP client usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ raven-erlang
 raven-erlang is an Erlang client for [Sentry](http://aboutsentry.com/) that integrates with the
 standard ```error_logger``` module.
 
+
+Requirements
+============
+
+* Erlang 25.1 or higher
+
 Quick Start
 ===========
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,9 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 noet syntax=erlang
-{erl_opts, [ warnings_as_errors,
-             warn_export_all,
-             {platform_define, "^R14", no_callbacks}
-           ]
-}.
+{erl_opts, [
+    warnings_as_errors,
+    warn_export_all
+]}.
 
 {deps, [jsx]}.
 

--- a/src/raven.erl
+++ b/src/raven.erl
@@ -33,7 +33,8 @@ capture(Message, Params) when is_list(Message) ->
 	capture(unicode:characters_to_binary(Message), Params);
 capture(Message, Params) ->
 	{ok, Body} = capture_prepare(Message, Params),
-	capture_with_backoff_send(Body).
+	{ok, _Backoff} = capture_with_backoff_send(Body),
+    ok.
 
 capture_prepare(Message, Params) ->
 	Cfg = get_config(),

--- a/src/raven_logger_backend.erl
+++ b/src/raven_logger_backend.erl
@@ -159,13 +159,12 @@ logger_backend_test_() ->
 
 test_setup() ->
   error_logger:tty(false),
-  persistent_term:put(?RAVEN_SSL_PERSIST_KEY, {ssl, []}),
-  meck:new(raven_send_sentry_safe),
-  meck:new(httpc),
+  meck:new(raven_send_sentry_safe, [passthrough]),
+  meck:new(httpc, [passthrough]),
   meck:expect(raven_send_sentry_safe, capture, 2, fun mock_capture/2),
   meck:expect(httpc, set_options, 1, fun(_) -> ok end),
   meck:expect(httpc, request, 5, fun mock_request/5),
-  application:start(raven), %% To se key vsn
+  ok = application:start(raven),
   application:set_env(raven, ipfamily, dummy),
   application:set_env(raven, uri, "http://foo"),
   application:set_env(raven, public_key, <<"hello">>),
@@ -180,8 +179,7 @@ test_teardown(_) ->
   application:unset_env(raven, public_key),
   application:unset_env(raven, private_key),
   application:unset_env(raven, project),
-  application:stop(raven),
-  persistent_term:erase(?RAVEN_SSL_PERSIST_KEY),
+  ok = application:stop(raven),
   error_logger:tty(true),
   ok.
 

--- a/src/raven_send_sentry_safe.erl
+++ b/src/raven_send_sentry_safe.erl
@@ -66,7 +66,7 @@ qlen() ->
 
 raven_capture(Message, Args) ->
   {ok, Body} = raven:capture_prepare(Message, Args),
-  case raven:capture_with_backoff_send(Body, true) of
+  case raven:capture_with_backoff_send(Body) of
     ok ->
       {ok, current_time()};
     {ok, Seconds} ->

--- a/test/raven_test.erl
+++ b/test/raven_test.erl
@@ -13,7 +13,7 @@ all_test_() ->
     ]}}.
 
 simple_capture_() ->
-    raven:capture(foo, []).
+    ?assertEqual(ok, raven:capture(foo, [])).
 
 %--- Harness -------------------------------------------------------------------
 


### PR DESCRIPTION
> **Warning**
> This bumps the Erlang version requirement to OTP 25.1!

This PR
* uses correct SSL options to avoid SSL errors on OTP 26+
* removes the old "async" functionality. It was only used on manual captures, but hid the HTTP result and left in the process message queue (leading to a memory leak)