### PR TITLE
Add rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ To add the raven backend:
 Advanced Usage
 ==============
 
+### Manual Logging
+
 You can log directly events to sentry using the ```raven:capture/2``` function, for example:
 
 ```erlang
@@ -109,4 +111,22 @@ raven:capture("Test Event", [
         {process_dictionnary, erlang:get()}
     ]}
 ]).
+```
+
+### Rate Limiting
+
+The Raven application can rate limit the number of events sent to Sentry. By
+default rate limiting is disabled. To enable, configure the application
+environment variable `rate_limit` with `{Intensity, Period}` where
+`Intensity` is the maximum number of error reports in the time `Period` in
+milliseconds.
+
+Example `sys.config`:
+
+```erlang
+[
+    {raven, [
+        {rate_limit, {250, 60_000}} % No more than 250 reports per minute
+    ]}
+]
 ```

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
     warn_export_all
 ]}.
 
-{deps, [jsx]}.
+{deps, [jsx, fuse]}.
 
 {profiles, [
     {test, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,8 +1,11 @@
 {"1.2.0",
-[{<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0}]}.
+[{<<"fuse">>,{pkg,<<"fuse">>,<<"2.5.0">>},0},
+ {<<"jsx">>,{pkg,<<"jsx">>,<<"3.1.0">>},0}]}.
 [
 {pkg_hash,[
+ {<<"fuse">>, <<"71AFA90BE21DA4E64F94ABBA9D36472FAA2D799C67FEDC3BD1752A88EA4C4753">>},
  {<<"jsx">>, <<"D12516BAA0BB23A59BB35DCCAF02A1BD08243FCBB9EFE24F2D9D056CCFF71268">>}]},
 {pkg_hash_ext,[
+ {<<"fuse">>, <<"7F52A1C84571731AD3C91D569E03131CC220EBAA7E2A11034405F0BAC46A4FEF">>},
  {<<"jsx">>, <<"0C5CC8FDC11B53CC25CF65AC6705AD39E54ECC56D1C22E4ADB8F5A53FB9427F3">>}]}
 ].

--- a/src/raven.app.src
+++ b/src/raven.app.src
@@ -8,7 +8,8 @@
 		crypto,
 		public_key,
 		ssl,
-		inets
+		inets,
+		fuse
 	]},
 	{mod, {raven_app, []}},
 	{env, [
@@ -17,6 +18,7 @@
 		{public_key, ""},
 		{private_key, ""},
 		{error_logger, false},
-		{ipfamily, inet}
+		{ipfamily, inet},
+		{rate_limit, false}
 	]}
 ]}.

--- a/src/raven_app.erl
+++ b/src/raven_app.erl
@@ -51,6 +51,7 @@ start(_StartType, _StartArgs) ->
 			end,
 			case raven_sup:start_link() of
 				{ok, Pid} ->
+					raven_rate_limit:setup(),
 					{ok, Pid};
 				Error ->
 					Error
@@ -67,7 +68,8 @@ stop(_State) ->
 			ok
 	end,
     ok = inets:stop(httpc, ?RAVEN_HTTPC_PROFILE),
-    true = persistent_term:erase(?RAVEN_SSL_PERSIST_KEY).
+    true = persistent_term:erase(?RAVEN_SSL_PERSIST_KEY),
+    raven_rate_limit:teardown().
 
 %% @private
 ensure_started(App) ->

--- a/src/raven_rate_limit.erl
+++ b/src/raven_rate_limit.erl
@@ -1,0 +1,55 @@
+-module(raven_rate_limit).
+
+% API
+-export([setup/0]).
+-export([teardown/0]).
+-export([run/1]).
+-export([delay/1]).
+
+%--- API -----------------------------------------------------------------------
+
+setup() ->
+    Result = case application:get_env(raven, rate_limit, false) of
+        {Intensity, Period} ->
+            FuseConfig = {{standard, Intensity, Period}, {reset, Period}},
+            ok = fuse:install(?MODULE, FuseConfig),
+            {enabled, atomics:new(1, [{signed, false}])};
+        false ->
+            disabled
+    end,
+    persistent_term:put(?MODULE, Result).
+
+teardown() ->
+    case persistent_term:get(?MODULE) of
+        {enabled, _} -> fuse:remove(?MODULE);
+        disabled -> ok
+    end,
+    persistent_term:erase(?MODULE).
+
+run(Fun) ->
+    case persistent_term:get(?MODULE) of
+        disabled ->
+            Fun();
+        {enabled, Atomics} ->
+            RetryAfter = atomics:get(Atomics, 1),
+            case erlang:system_time(second) > RetryAfter of
+                true ->
+                    case fuse:ask(?MODULE, async_dirty) of
+                        blown ->
+                            {error, {rate_limit, local}};
+                        _ ->
+                            ok = fuse:melt(?MODULE),
+                            Fun()
+                    end;
+                false ->
+                    {error, {rate_limit, remote}}
+            end
+    end.
+
+delay(Seconds) when Seconds > 0 ->
+    case persistent_term:get(?MODULE) of
+        disabled -> ok;
+        {enabled, Atomics} ->
+            RetryAfter = erlang:system_time(second) + Seconds + 1,
+            atomics:put(Atomics, 1, RetryAfter)
+    end.


### PR DESCRIPTION
This PR adds a configurable rate limiting to Raven, to avoid overloading a Sentry instance. The rate limiting is disabled by default, but can be configured with a maximum intensity per period (see the README for details).

The PR also starts respecting the `429 Too Many Requests` response from Sentry and the delay enforced in the `Retry-After` header.