### PR TITLE
chore: changed log level to error

### DIFF
--- a/src/raven_app.erl
+++ b/src/raven_app.erl
@@ -39,7 +39,7 @@ start(_StartType, _StartArgs) ->
 			end,
 			case application:get_env(otp_logger) of
 				{ok, true} ->
-					logger:add_handler(raven_otp_logger, raven_logger_backend, #{level => warning
+					logger:add_handler(raven_otp_logger, raven_logger_backend, #{level => error
 						, filter_default => log
 						, filters => [{ssl,      {fun logger_filters:domain/2, {stop, sub, [ssl]}}}
 									 ,{progress, {fun logger_filters:domain/2, {stop, equal, [progress]}}}


### PR DESCRIPTION
To diminish the load on Sentry, and making it more useful, we change log level from warning to error.