### PR TITLE
fix: handle errors returned from httpc

### DIFF
--- a/src/raven.erl
+++ b/src/raven.erl
@@ -104,10 +104,10 @@ capture_with_backoff_send(Body) ->
         ?RAVEN_HTTPC_PROFILE
 	),
 	case Result of
-	   {ok, {{_, 429, _}, H, _}} ->
-		    DelaySeconds = list_to_integer(proplists:get_value("retry-after", H)),
+		{ok, {{_, 429, _}, Headers, _}} ->
+			DelaySeconds = list_to_integer(proplists:get_value("retry-after", Headers)),
 			raven_rate_limit:delay(DelaySeconds);
-	   _ ->
+		_ ->
 			ok
     end,
 	ok.


### PR DESCRIPTION
## Problem

The code we introduced in #12 to integrate with `logger` also introduced harder expectations on the httpc request send as a side effect when extracting the "retry-after" on 429.

Compare for the Hex version of raven-erlang does not impose this: https://github.com/artemeff/raven-erlang/blob/master/src/raven.erl#L87-L91

This can lead to badmatch errors, which if too intense crash the supervisor.

## Solution

Match httpc errors as well as ok results.

## Testing

I reproduced the problem locally by starting with `rebar3 shell` and provoking things a bit.

```
1> application:ensure_all_started(raven).
{ok,[sasl,fuse,raven]}
2> application:set_env(raven, uri, "https://localhost:4711").
ok
3> raven_send_sentry_safe:capture("Hello, Sailor!", []).
ok
4> =ERROR REPORT==== 8-Apr-2025::11:20:18.356749 ===
** Generic server raven_send_sentry_safe terminating
** Last message in was {'$gen_cast',{capture,"Odelay!",[]}}
** When Server state == #{backoff_until => 1744104120489651}
** Reason for termination ==
** {{case_clause,
        {error,
            {failed_connect,
                [{to_address,{"localhost",4711}},
                 {inet,[inet],econnrefused}]}}},
...
a few more repeats of raven_send_sentry_safe:capture("Odelay!", []).
...

=INFO REPORT==== 8-Apr-2025::11:22:03.020895 ===
    application: raven
    exited: shutdown
    type: temporary
```

With the changes in this PR the application stays up (but fails silently to capture errors, like `artemeff/raven-erlang` does).