### PR TITLE
fix: untangle retry code from bound variable

### DIFF
--- a/src/raven.erl
+++ b/src/raven.erl
@@ -116,7 +116,7 @@ handle_429({{_, 429, _}, Headers, _}) ->
 	RetryAfter = list_to_integer(proplists:get_value("retry-after", Headers)),
 	raven_rate_limit:delay(RetryAfter);
 handle_429(_) ->
-    ok.
+	ok.
 
 -spec user_agent() -> iolist().
 user_agent() ->

--- a/src/raven.erl
+++ b/src/raven.erl
@@ -104,13 +104,19 @@ capture_with_backoff_send(Body) ->
         ?RAVEN_HTTPC_PROFILE
 	),
 	case Result of
-		{ok, {{_, 429, _}, Headers, _}} ->
-			DelaySeconds = list_to_integer(proplists:get_value("retry-after", Headers)),
-			raven_rate_limit:delay(DelaySeconds);
+		{ok, Response} ->
+			handle_429(Response),
+			ok;
 		_ ->
 			ok
     end,
 	ok.
+
+handle_429({{_, 429, _}, Headers, _}) ->
+	RetryAfter = list_to_integer(proplists:get_value("retry-after", Headers)),
+	raven_rate_limit:delay(RetryAfter);
+handle_429(_) ->
+    ok.
 
 -spec user_agent() -> iolist().
 user_agent() ->


### PR DESCRIPTION
I made a mess in #32 inadvertently reusing a variable name in a match.

This PR untangles that mess.